### PR TITLE
Add troubleshooting note for WSL

### DIFF
--- a/README.md
+++ b/README.md
@@ -373,6 +373,11 @@ Host box-initramfs
 	UserKnownHostsFile ~/.ssh/known_hosts.initramfs
 ```
 
+## Troubleshooting
+
+* **`Exec format error` when executing the `chroot` command**  
+  Make sure `binfmt-support` is installed. When using Windows Subsystem for Linux (WSL), it might be neccesarry to call `update-binfmts --enable` manually after installing (see [this issue](https://github.com/microsoft/WSL/issues/7181#issuecomment-885474697)).
+
 ## Resources
 
 - https://www.kali.org/docs/arm/raspberry-pi-with-luks-disk-encryption/


### PR DESCRIPTION
When using debian on WSL, the `binfmt-support` scripts are not called properly (see linked issue). This causes the `chroot` command to fail.

I'm aware that this is a problem with the host OS, so I completely understand if you don't want to merge this. But I think WSL is a very easy way to follow this guide for Windows users.